### PR TITLE
Fix another PHP Fatal error

### DIFF
--- a/module/network.php
+++ b/module/network.php
@@ -1,5 +1,5 @@
 <?php
-$server_addr = isset($_SERVER['SERVER_ADDR'])? $_SERVER['SERVER_ADDR']:isset($_SERVER["HTTP_HOST"])?$_SERVER["HTTP_HOST"]:"";
+$server_addr = isset($_SERVER['SERVER_ADDR'])? $_SERVER['SERVER_ADDR']:(isset($_SERVER["HTTP_HOST"])?$_SERVER["HTTP_HOST"]:"");
 $remote_addr = isset($_SERVER['REMOTE_ADDR'])? $_SERVER['REMOTE_ADDR']:"";
 $default_port = 13123;
 $winbinary = (strtolower(substr(php_uname(),0,3))=="win")? "<option>executable</option>":"";


### PR DESCRIPTION
Added parentheses around the stacked ternary operator to prevent``PHP Fatal error:  Unparenthesized `a ? b : c ? d : e` is not supported. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)``